### PR TITLE
Fixed generate_class_instance relationships failing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ Homepage = "https://github.com/bsgip/assertical"
 [project.optional-dependencies]
 all = ["assertical[dev,fastapi,pandas,pydantic,postgres,xml]"]
 dev = ["bandit", "flake8", "mypy", "black", "coverage"]
-fastapi = ["fastapi", "asgi_lifespan"]
+fastapi = ["fastapi[standard]", "asgi_lifespan", "uvicorn"]
 pandas = ["pandas", "pandas_stubs", "numpy"]
 pydantic = ["pydantic"]
 postgres = ["pytest-postgresql", "psycopg", "sqlalchemy>=2.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "assertical"
-version = "0.0.1"
+version = "0.0.2"
 description = "Assertical - a modular library for helping write (async) integration/unit tests for fastapi/sqlalchemy/postgres projects"
 authors = [{ name = "Battery Storage and Grid Integration Program" }]
 readme = "README.md"

--- a/src/assertical/fake/http.py
+++ b/src/assertical/fake/http.py
@@ -9,7 +9,7 @@ from httpx._types import HeaderTypes, RequestContent
 
 # HTTPMethod is only defined in python >= 3.11
 try:
-    from http import HTTPMethod  # type: ignore
+    from http import HTTPMethod
 except ImportError:
 
     class HTTPMethod(Enum):  # type: ignore

--- a/tests/fake/test_generator_complex_example.py
+++ b/tests/fake/test_generator_complex_example.py
@@ -1,0 +1,93 @@
+from typing import Optional
+
+from sqlalchemy import VARCHAR, ForeignKey
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from assertical.fake.generator import generate_class_instance
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Student(Base):
+    """This is to stress test some complex relationships"""
+
+    __tablename__ = "_student"
+
+    student_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+
+    # Each student has multiple report cards
+    report_cards: Mapped[list["ReportCard"]] = relationship(
+        back_populates="student",
+        lazy="raise",
+        cascade="all, delete",
+        passive_deletes=True,
+    )
+
+
+class ReportCard(Base):
+
+    __tablename__ = "_report_card"
+
+    report_card_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    student_id: Mapped[int] = mapped_column(ForeignKey("_student.student_id", ondelete="CASCADE"))
+
+    student: Mapped["Student"] = relationship(back_populates="report_cards")
+
+    # Each report card has a unique Math/English result
+    math_result: Mapped[Optional["MathResult"]] = relationship(
+        back_populates="report_card", uselist=False, lazy="raise"
+    )
+    english_result: Mapped[Optional["EnglishResult"]] = relationship(
+        back_populates="report_card", uselist=False, lazy="raise"
+    )
+
+
+class MathResult(Base):
+    __tablename__ = "_math_result"
+    math_result_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    report_card_id: Mapped[int] = mapped_column(ForeignKey("_report_card.report_card_id", ondelete="CASCADE"))
+    grade: Mapped[str] = mapped_column(VARCHAR(length=32), nullable=False)
+
+    report_card: Mapped["ReportCard"] = relationship(back_populates="math_result", lazy="raise", single_parent=True)
+
+
+class EnglishResult(Base):
+    __tablename__ = "_english_result"
+    english_result_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    report_card_id: Mapped[int] = mapped_column(ForeignKey("_report_card.report_card_id", ondelete="CASCADE"))
+    grade: Mapped[str] = mapped_column(VARCHAR(length=32), nullable=False)
+
+    report_card: Mapped["ReportCard"] = relationship(back_populates="english_result", lazy="raise", single_parent=True)
+
+
+def test_generate_complex_relationships():
+    """Regression test for picking up a known issue with generate_relationships and more complex types"""
+
+    student: Student = generate_class_instance(Student, generate_relationships=True)
+    assert isinstance(student, Student)
+
+    # Student should have generated a report card
+    assert isinstance(student.report_cards, list)
+    assert len(student.report_cards) == 1
+
+    # Report card should have generated with links to English/Math result
+    report_card = student.report_cards[0]
+    assert isinstance(report_card.english_result, EnglishResult)
+    assert isinstance(report_card.math_result, MathResult)
+    assert report_card.student is None or id(report_card.student) == id(
+        student
+    ), "Back reference will not be populated by our code - SQLAlchemy might auto fill but that's OK"
+
+    english_result = report_card.english_result
+    assert english_result.report_card is None or id(english_result.report_card) == id(
+        report_card
+    ), "Back reference will not be populated by our code - SQLAlchemy might auto fill but that's OK"
+
+    math_result = report_card.math_result
+    assert math_result.report_card is None or id(math_result.report_card) == id(
+        report_card
+    ), "Back reference will not be populated by our code - SQLAlchemy might auto fill but that's OK"
+
+    assert english_result.grade != math_result.grade, "Values should be using unique seeds"


### PR DESCRIPTION
generate_class_instance could get mixed up with generate_relationships due to a faulty anti recursion check. This PR fixes that (and simplifies the check)