### PR TITLE
Added generator extensions and fixtures to manage

### DIFF
--- a/src/assertical/fixtures/environment.py
+++ b/src/assertical/fixtures/environment.py
@@ -1,20 +1,17 @@
 import os
 from contextlib import contextmanager
-from typing import Generator, Optional
+from typing import Callable, Generator
+
+from assertical.snapshot import snapshot_kvp_store
 
 
-def update_environment_variable(name: str, new_value: Optional[str]) -> None:
-    """Updates/Deletes an environment variable with name. This applies to the current environment
+def delete_environment_variable(name: str) -> None:
+    """Deletes/unsets an environment variable with the specified name. If name DNE, nothing happens"""
 
-    name: The name of the environment variable to update
-    new_value: If None - the environment variable is deleted. Otherwise sets the value to new_value"""
-    if new_value is None:
-        if name in os.environ:
-            # Yes, we need to maintain the env AND the os.environ for deletion
-            os.unsetenv(name)
-            del os.environ[name]
-    else:
-        os.environ[name] = new_value
+    # Yes, we need to maintain the env AND the os.environ for deletion
+    os.unsetenv(name)
+    if name in os.environ:
+        del os.environ[name]
 
 
 @contextmanager
@@ -31,27 +28,10 @@ def environment_snapshot() -> Generator[dict[str, str], None, None]:
     # At this point the env modifications are reset (as soon as the with statement exits)
     """
 
-    # Take a snapshot
-    original_snapshot: dict[str, str] = dict(os.environ.items())
+    snapshot_env: Callable = lambda: dict(os.environ.items())
 
-    # Return snapshot but mainly wait until the context is exited
-    yield original_snapshot
+    def update_env(name: str, value: str) -> None:
+        os.environ[name] = value
 
-    # Reset environment to snapshot
-    # Firstly iterate the current environment to see what we need to rectify
-    visited_variables = set()
-    for k, v in os.environ.items():
-        visited_variables.add(k)
-
-        old_value = original_snapshot.get(k, None)
-        if v != old_value:
-            update_environment_variable(k, old_value)
-
-    # Next iterate our stored snapshot to find keys that may have been deleted and didn't appear in our previous
-    # enumeration
-    for k, v in original_snapshot.items():
-        if k in visited_variables:
-            continue
-
-        # At this point - we have a variable in the snapshot that didn't appear in the current env - restore it
-        update_environment_variable(k, v)
+    with snapshot_kvp_store(snapshot_env, update_env, delete_environment_variable) as original_snapshot:
+        yield original_snapshot

--- a/src/assertical/fixtures/generator.py
+++ b/src/assertical/fixtures/generator.py
@@ -1,0 +1,44 @@
+from contextlib import contextmanager
+from typing import Generator
+
+from assertical.fake.generator import (
+    BASE_CLASS_PUBLIC_MEMBERS,
+    CLASS_INSTANCE_GENERATORS,
+    CLASS_MEMBER_FETCHERS,
+    PRIMITIVE_VALUE_GENERATORS,
+)
+from assertical.snapshot import snapshot_kvp_store
+
+
+@contextmanager
+def _dict_snapshot(d: dict) -> Generator[None, None, None]:
+    with snapshot_kvp_store(lambda: dict(d), lambda k, v: d.update({k: v}), lambda k: d.pop(k)):
+        yield
+
+
+@contextmanager
+def generator_registry_snapshot() -> Generator[None, None, None]:
+    """This class is designed to snapshot the current state of the installed assertical.fake.generator registrations so
+    that a test can override/add to their behaviour without polluting the global registry values beyond the test scope
+
+    usage:
+
+    with generator_registry_snapshot():
+        register_value_generator(MyPrimitiveType, lambda seed: MyPrimitiveType(seed))
+        register_base_type(
+            MyBaseType,
+            DEFAULT_CLASS_INSTANCE_GENERATOR,
+            DEFAULT_MEMBER_FETCHER,
+        )
+
+        # Do test body
+
+
+    # At this point the registry modifications are reset (as soon as the with statement exits)
+    """
+
+    with _dict_snapshot(PRIMITIVE_VALUE_GENERATORS):
+        with _dict_snapshot(CLASS_INSTANCE_GENERATORS):
+            with _dict_snapshot(CLASS_MEMBER_FETCHERS):
+                with _dict_snapshot(BASE_CLASS_PUBLIC_MEMBERS):
+                    yield

--- a/src/assertical/snapshot.py
+++ b/src/assertical/snapshot.py
@@ -1,0 +1,67 @@
+from contextlib import contextmanager
+from typing import Callable, Generator, TypeVar, cast
+
+KeyType = TypeVar("KeyType")
+ValueType = TypeVar("ValueType")
+
+
+@contextmanager
+def snapshot_kvp_store(
+    snapshot: Callable[[], dict[KeyType, ValueType]],
+    update: Callable[[KeyType, ValueType], None],
+    delete: Callable[[KeyType], None],
+) -> Generator[dict[KeyType, ValueType], None, None]:
+    """This class is designed to be a general purpose context manager for snapshotting some key value store upon enter
+    and then restoring the key value store to its snapshotted state upon release.
+
+    It's general purpose as two callables must be supplied - one will perform a snapshot into a dict, the second
+    will provide the ability to update/delete
+
+    snapshot: When called, snapshot whatever KVP store and return the key/values as a dict. Please ensure that the
+              returned value does NOT reference the original KVP store items.
+    update: When called, update/insert whatever KVP store with this key/value pair.
+    delete: When called, delete key from the whatever KVP store.
+
+    usage:
+
+    MY_KEY_VALUE_STORE = {"a": 1, "b": 2}
+    with snapshot_kvp_store(
+        lambda: dict(MY_KEY_VALUE_STORE),  # The snapshot function
+        lambda k, v: MY_KEY_VALUE_STORE.update({k: v}), # The update function
+        lambda k: MY_KEY_VALUE_STORE.pop(k), # The delete function
+    ):
+        print(MY_KEY_VALUE_STORE)  # {"a": 1, "b": 2} # Nothing has changed
+        MY_KEY_VALUE_STORE["a"] = 11
+        del MY_KEY_VALUE_STORE["b"]
+        MY_KEY_VALUE_STORE["c"] = 3
+        print(MY_KEY_VALUE_STORE)  # {"a": 11, "c": 3}  # Updates have been applied
+    print(MY_KEY_VALUE_STORE)  # {"a": 1, "b": 2} # Everything reverted to original state
+    """
+
+    # Take a snapshot
+    original_snapshot: dict[KeyType, ValueType] = snapshot()
+
+    # Return snapshot but mainly wait until the context is exited
+    yield original_snapshot
+
+    # Reset environment to snapshot
+    # Firstly iterate the current environment to see what we need to rectify
+    final_snapshot: dict[KeyType, ValueType] = snapshot()
+    visited_keys = set()
+    for k, v in final_snapshot.items():
+        visited_keys.add(k)
+
+        if k in original_snapshot:
+            old_value: ValueType = cast(ValueType, original_snapshot.get(k))
+            update(k, old_value)
+        else:
+            delete(k)
+
+    # Next iterate our stored snapshot to find keys that may have been deleted and didn't appear in our previous
+    # enumeration
+    for k, v in original_snapshot.items():
+        if k in visited_keys:
+            continue
+
+        # At this point - we have a variable in the snapshot that didn't appear in the current env - restore it
+        update(k, v)

--- a/tests/fake/test_generator.py
+++ b/tests/fake/test_generator.py
@@ -1,6 +1,6 @@
 import sys
 from dataclasses import dataclass
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from enum import IntEnum, IntFlag, auto
 from typing import List, Optional, Union
 
@@ -202,6 +202,9 @@ def test_generate_value():
     with pytest.raises(Exception):
         generate_value(list[int], 1)
 
+    assert generate_value(str, 1, True) == generate_value(str, 1, True)
+    assert generate_value(str, 1, True) is not generate_value(str, 1, True)
+
 
 def test_get_enum_type_non_enums():
     assert get_enum_type(None, True) is None
@@ -338,6 +341,7 @@ def test_is_generatable_type():
     assert is_generatable_type(Union[type(None), str])
     assert is_generatable_type(Mapped[Optional[int]])
     assert is_generatable_type(Mapped[Optional[datetime]])
+    assert is_generatable_type(Optional[timedelta])
 
     assert not is_generatable_type(ChildClass)
     assert not is_generatable_type(ParentClass)

--- a/tests/fixtures/test_environment.py
+++ b/tests/fixtures/test_environment.py
@@ -4,8 +4,8 @@ from typing import Optional
 import pytest
 
 from assertical.fixtures.environment import (
+    delete_environment_variable,
     environment_snapshot,
-    update_environment_variable,
 )
 
 NEVER_EXISTS_NAME = "92y539hgf3_123akjh"
@@ -39,8 +39,14 @@ def test_environment_snapshot(kvps: list[tuple[str, Optional[str]]]):
 
         # Mess with the environment
         for k, v in kvps:
-            update_environment_variable(k, v)
 
+            # Make the change
+            if v is None:
+                delete_environment_variable(k)
+            else:
+                os.environ[k] = v
+
+            # Ensure it changed
             if v is not None:
                 assert os.environ[k] == v
             else:

--- a/tests/fixtures/test_generator_fixtures.py
+++ b/tests/fixtures/test_generator_fixtures.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+
+import pytest
+
+from assertical.fake.generator import (
+    DEFAULT_CLASS_INSTANCE_GENERATOR,
+    DEFAULT_MEMBER_FETCHER,
+    generate_class_instance,
+    register_base_type,
+    register_value_generator,
+)
+from assertical.fixtures.generator import generator_registry_snapshot
+
+
+@dataclass
+class MyDataClass:
+    my_id: int
+
+
+class MyBaseClass:
+    pass
+
+
+class MySimpleClass:
+    diff_id: int = 1
+
+    def __init__(self, diff_id: int) -> None:
+        self.diff_id = diff_id
+
+
+class MyGenerationClass(MyBaseClass):
+    my_id: int = 1
+    my_str: str = "a"
+    my_simple_class: MySimpleClass = None
+
+    def __init__(self, my_id: int, my_str: str, my_simple_class: MySimpleClass) -> None:
+        super().__init__()
+
+        self.my_id = my_id
+        self.my_str = my_str
+        self.my_simple_class = my_simple_class
+
+
+def test_generator_registry_snapshot():
+
+    with pytest.raises(Exception):
+        generate_class_instance(MyGenerationClass)  # Initially this type won't work
+    assert isinstance(generate_class_instance(MyDataClass), MyDataClass)  # but this type will as it's a dataclass
+
+    with generator_registry_snapshot():
+        # Nothing has changed yet
+        with pytest.raises(Exception):
+            generate_class_instance(MyGenerationClass)
+        assert isinstance(generate_class_instance(MyDataClass), MyDataClass)
+
+        # Now register the types and recheck
+        register_value_generator(MySimpleClass, lambda seed: MySimpleClass(seed))
+        register_base_type(MyBaseClass, DEFAULT_CLASS_INSTANCE_GENERATOR, DEFAULT_MEMBER_FETCHER)
+        assert isinstance(generate_class_instance(MyDataClass), MyDataClass)  # Should continue to work
+        assert isinstance(generate_class_instance(MyGenerationClass), MyGenerationClass)  # Should now work
+
+    # Now we've exited the context-  the registrations should've been removed
+    with pytest.raises(Exception):
+        generate_class_instance(MyGenerationClass)  # Registration should've been unwound
+    assert isinstance(generate_class_instance(MyDataClass), MyDataClass)  # This should continue to work

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+import pytest
+
+from assertical.snapshot import snapshot_kvp_store
+
+DELETE_VALUE = {"delete": "me"}
+
+
+@pytest.mark.parametrize(
+    "original_store, operations",
+    [
+        ({}, []),
+        ({}, [("a", 1)]),
+        ({}, [("a", 1), ("a", 2)]),
+        ({"a": 1, "b": 2}, [("a", DELETE_VALUE), ("b", "stringval"), ("c", 99)]),
+        ({"a": 1, "b": 2}, [("a", DELETE_VALUE), ("b", "stringval"), ("c", 99), ("c", 98), ("a", 1)]),
+        ({"a": 1, "b": 2}, [("a", DELETE_VALUE), ("b", DELETE_VALUE)]),
+        ({"a": None, "b": 2}, [("a", 1), ("b", None), ("c", None)]),
+    ],
+)
+def test_snapshot_kvp_store(original_store: dict[str, Any], operations: list[tuple[str, Any]]):
+
+    original_store_clone = dict(original_store)
+
+    with snapshot_kvp_store(
+        lambda: dict(original_store),  # The snapshot function
+        lambda k, v: original_store.update({k: v}),  # The update function
+        lambda k: original_store.pop(k),  # The delete function
+    ):
+        # Apply each operation to original_store
+        for key, new_val in operations:
+            if new_val is DELETE_VALUE:
+                del original_store[key]
+            else:
+                original_store[key] = new_val
+
+            assert original_store != original_store_clone, "Validate a mutation has occurred"
+
+    # Ensure that after snapshot everything reverts
+    assert original_store == original_store_clone
+    assert original_store is not original_store_clone
+
+
+def test_snapshot_kvp_store_docs_example():
+    """Runs the basic example listed the docstring"""
+
+    MY_KEY_VALUE_STORE = {"a": 1, "b": 2}
+    saved_id = id(MY_KEY_VALUE_STORE)
+    with snapshot_kvp_store(
+        lambda: dict(MY_KEY_VALUE_STORE),  # The snapshot function
+        lambda k, v: MY_KEY_VALUE_STORE.update({k: v}),  # The update function
+        lambda k: MY_KEY_VALUE_STORE.pop(k),  # The delete function
+    ):
+        # Upon entering - nothing has changed
+        assert MY_KEY_VALUE_STORE == {"a": 1, "b": 2}
+        assert saved_id == id(MY_KEY_VALUE_STORE), "Reference is still the same"
+
+        # Apply changes, ensure they stick
+        MY_KEY_VALUE_STORE["a"] = 11
+        assert MY_KEY_VALUE_STORE == {"a": 11, "b": 2}
+        del MY_KEY_VALUE_STORE["b"]
+        assert MY_KEY_VALUE_STORE == {"a": 11}
+        MY_KEY_VALUE_STORE["c"] = 3
+        assert MY_KEY_VALUE_STORE == {"a": 11, "c": 3}
+
+    # Upon exiting - ensure everything reverts
+    assert MY_KEY_VALUE_STORE == {"a": 1, "b": 2}
+    assert saved_id == id(MY_KEY_VALUE_STORE), "Reference is still the same"


### PR DESCRIPTION
* generator types can now be registered via new global functions
* Added a generator snapshot fixture to revert the above on a test by test basis (based on an abstracted version of the env snapshot)
* Added support for timedelta