### PR TITLE
Added new error message and test for dict[str, Any] generation

### DIFF
--- a/src/assertical/fake/generator.py
+++ b/src/assertical/fake/generator.py
@@ -487,6 +487,14 @@ def generate_class_instance(  # noqa: C901
                     f"Type {t} has property {member.name} with type {member.declared_type} that cannot be generated"
                 )
 
+        if member.collection_type in (CollectionType.REQUIRED_DICT, CollectionType.OPTIONAL_DICT):
+            if member.second_type_to_generate is None and not (
+                optional_is_none and member.collection_type == CollectionType.OPTIONAL_DICT
+            ):
+                raise Exception(
+                    f"Type {t} has property {member.name} with type {member.declared_type} that cannot be generated"
+                )
+
         generated_value: Any = None
         empty_collection: bool = False
         collection_type: Optional[CollectionType] = member.collection_type

--- a/tests/fake/test_generator_dataclass.py
+++ b/tests/fake/test_generator_dataclass.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, time
-from typing import Generator, Optional
+from typing import Any, Generator, Optional
 from pathlib import Path
 
 import pytest
@@ -102,6 +102,25 @@ def test_dataclass_with_ungeneratable_type():
 
     # Check optional_is_none allows by-passing ungeneratable types
     generate_class_instance(DataclassWithUngeneratableType, optional_is_none=True)
+
+
+def test_dataclass_with_ungeneratable_dict_value_type():
+    """dict[str, Any] has an unresolvable value type - should raise a clear error, not crash cryptically."""
+
+    @dataclass
+    class DataclassWithUngeneratableDict:
+        d: dict[str, Any]
+
+    with pytest.raises(Exception, match="cannot be generated"):
+        generate_class_instance(DataclassWithUngeneratableDict, generate_relationships=True)
+
+    # Optional dict with optional_is_none=True should be bypassed (set to None) without raising
+    @dataclass
+    class DataclassWithOptionalUngeneratableDict:
+        d: Optional[dict[str, Any]]
+
+    result = generate_class_instance(DataclassWithOptionalUngeneratableDict, optional_is_none=True)
+    assert result.d is None
 
 
 def test_collections_dataclass():


### PR DESCRIPTION
v0.3.3 added native dict generation, which is great, but silently breaks when the dict **value** type is unresolvable by assertical (e.g. Any, Path, object). Instead of a clear error, generation crashes deep in the stack:

Exception: Type None does not inherit from one of dict_keys([...])

This is because enumerate_class_properties sets second_type_to_generate = None when the value type can't be resolved, but        generate_class_instance then passes None to generate_member, which calls generate_class_instance(None, ...) causing the crash.

This was already handled cleanly by **keys**:

if member.type_to_generate is None:
      if not (optional_is_none and member.is_optional):
          raise Exception(f"...cannot be generated")

Now added the error message to **values** to make it a little easier to trace. 

The reason why I think this is useful is from a cryptic issue I found after this upgrade in another repo. When generating a dict[str, Any] prior to assertical v0.3.3, the assertical_extensions fixture registered register_value_generator(dict, lambda _: {}), which intercepted any dict field and returned {} before assertical inspected the type arguments. This masked the fact that Any is not a type assertical can generate. Now these are no longer intercepted and fail with the error described above. This new message would have made things easier!